### PR TITLE
fix: change invalid revalidate value from true to 0

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -5,7 +5,7 @@ import { fetchUser } from "@/lib/actions/user.actions";
 import { currentUser } from "@clerk/nextjs";
 import { redirect } from "next/navigation";
 
-export const revalidate = true;
+export const revalidate = 0;
 
 export default async function Home() {
   let user;


### PR DESCRIPTION
- Fixed Next.js build error: 'Invalid revalidate value "true"'
- Changed revalidate from boolean true to number 0 on root page
- This enables dynamic revalidation on every request for the home feed